### PR TITLE
『:bug:』Fix: File Name of Jar file when invoked

### DIFF
--- a/code-compass.el
+++ b/code-compass.el
@@ -143,8 +143,7 @@
   "Run code-maat's COMMAND on REPOSITORY."
   (message "Producing code-maat %s report for %s..." command repository)
   (let ((source-file "./dependencies/code-maat-1.0.1-standalone.jar")
-        (maat-jar-p (s-contains-p "jar" c/code
-                                  -maat-command)))
+        (maat-jar-p (s-contains-p "jar" c/code-maat-command)))
     (unless (or (not maat-jar-p) (file-exists-p (c/expand-file-name source-file)))
       (mkdir (c/expand-file-name "dependencies") t)
       (url-copy-file "https://github.com/smontanari/code-forensics/raw/v3.0.0/lib/analysers/code_maat/code-maat-1.0.1-standalone.jar" (c/expand-file-name source-file) t))

--- a/code-compass.el
+++ b/code-compass.el
@@ -63,10 +63,10 @@
   (expand-file-name file-name c/path-to-code-compass))
 
 (defcustom c/code-maat-command
-  (format "java -jar %s/code-maat-1-1.jar" (c/expand-file-name "dependencies"))
+  (format "java -jar %s/code-maat-1.0.1-standalone.jar" (c/expand-file-name "dependencies"))
   "Command to run Code-maat (https://github.com/adamtornhill/code-maat). Currently defaults to use docker because easier to setup."
   :group 'code-compass
-  :options `(,(format "java -jar %s/code-maat-1-1.jar" (c/expand-file-name "dependencies")) "docker run -v /tmp/:/data code-maat-app"))
+  :options `(,(format "java -jar %s/code-maat-1.0.1-standalone.jar" (c/expand-file-name "dependencies")) "docker run -v /tmp/:/data code-maat-app"))
 
 (defcustom c/preferred-browser
   "chromium"
@@ -143,7 +143,8 @@
   "Run code-maat's COMMAND on REPOSITORY."
   (message "Producing code-maat %s report for %s..." command repository)
   (let ((source-file "./dependencies/code-maat-1.0.1-standalone.jar")
-        (maat-jar-p (s-contains-p "jar" c/code-maat-command)))
+        (maat-jar-p (s-contains-p "jar" c/code
+                                  -maat-command)))
     (unless (or (not maat-jar-p) (file-exists-p (c/expand-file-name source-file)))
       (mkdir (c/expand-file-name "dependencies") t)
       (url-copy-file "https://github.com/smontanari/code-forensics/raw/v3.0.0/lib/analysers/code_maat/code-maat-1.0.1-standalone.jar" (c/expand-file-name source-file) t))


### PR DESCRIPTION
The download name is different from the running name

fixes #7 