### PR TITLE
Extract c/exclude-directories variable for cloc reporting

### DIFF
--- a/code-compass.el
+++ b/code-compass.el
@@ -74,6 +74,11 @@
   "Browser to use to open graphs served by webserver."
   :group 'code-compass)
 
+(defcustom c/exclude-directories
+  '("node_modules" "bower_components" "vendor" "tmp")
+  "A list of directory patterns to exclude from reports. Contents are passed to the cloc executable via its --exclude-dir argument."
+  :group 'code-compass)
+
 (defun c/doctor ()
   "Report if and what dependencies are missing."
   (interactive)
@@ -187,10 +192,10 @@
   repository)
 
 (defun c/produce-cloc-report (repository)
-  "Create cloc report for REPOSITORY."
+  "Create cloc report for REPOSITORY. To filter specific subdirectories out of this report, edit the variable `c/exclude-directories'."
   (message "Producing cloc report...")
   (shell-command
-   (format "(cd %s; cloc ./ --by-file --csv --quiet) > cloc.csv" repository))
+   (format "(cd %s; cloc ./ --by-file --csv --quiet --exclude-dir=%s) > cloc.csv" repository (string-join c/exclude-directories ",")))
   repository)
 
 (defun c/copy-file (file-name directory)

--- a/code-compass.el
+++ b/code-compass.el
@@ -34,6 +34,7 @@
 ;; See documentation on https://github.com/ag91/code-compass
 
 ;;; Code:
+(require 'dash)
 (require 'f)
 (require 's)
 (require 'simple-httpd)
@@ -107,7 +108,7 @@
 (defun c/request-date (days|months &optional time)
   "Request date in days or months by asking how many DAYS|MONTHS ago. Optionally give TIME from which to start."
   (interactive
-   (list (completing-read "From how long ago?" c/default-periods)))
+   (list (completing-read "From how long ago? " c/default-periods)))
   (when (not (string= days|months "beginning"))
     (format-time-string
      "%Y-%m-%d"


### PR DESCRIPTION
Addresses the "reports display untracked library code" problem from https://github.com/ag91/code-compass/issues/13.

Additionally adds two fairly trivial improvements: explicitly requiring the dash.el dependency and adding a space to the end of a `completing-read` prompt; these edits are in a separate commit and could easily be dropped if desired.