### PR TITLE
Use buffer-file-name to avoid file name collisions

### DIFF
--- a/code-compass.el
+++ b/code-compass.el
@@ -1366,7 +1366,7 @@ If a file `repos-cluster.txt' exists with a list of repositories in the current 
     (shell-command-to-string
      (concat
       "git shortlog HEAD -n -s -- "
-      (buffer-name)))))
+      (buffer-file-name)))))
 
 (defun c/display-contributors ()
   "Show in minibuffer the main contributors of this file."


### PR DESCRIPTION
This is a small improvement I had to make for myself: given two files like `path/to/some-file.ext` and `different/path/to/another/some-file.ext`, opening the second failed to list contributors because `buffer-name` returned `some-file.ext<2>` instead of `some-file.ext`. Using `buffer-file-name` resolved this name collision.