### PR TITLE
Update contributors function

### DIFF
--- a/code-compass.el
+++ b/code-compass.el
@@ -1728,11 +1728,12 @@ Starting DATE reduces scope of Git log.
 
 (defun code-compass--contributors-list-for-current-buffer ()
   "Return contributors of this file if it is in a git repository."
-  (when (vc-root-dir)
-    (shell-command-to-string
-     (concat
-      "git shortlog HEAD -n -s -- "
-      (buffer-file-name)))))
+  (if (vc-root-dir)
+      (shell-command-to-string
+       (concat
+        "git shortlog HEAD -n -s -- "
+        (buffer-file-name)))
+    "    No history yet"))
 
 (defun code-compass-display-contributors ()
   "Show in minibuffer the main contributors of this file."

--- a/code-compass.el
+++ b/code-compass.el
@@ -4,7 +4,7 @@
 
 ;; Author: Andrea <andrea-dev@hotmail.com>
 ;; Version: 0.1.3
-;; Package-Requires: ((emacs "26.1") (s "1.12.0") (dash "2.13") (async "1.9.7") (simple-httpd "1.5.1"))
+;; Package-Requires: ((emacs "26.1") (s "1.12.0") (dash "2.13") (async "1.9.7") (simple-httpd "1.5.1") (f "0.20"))
 ;; Keywords: tools, extensions, help
 ;; Homepage: https://github.com/ag91/code-compass
 
@@ -1738,7 +1738,15 @@ Starting DATE reduces scope of Git log.
   "Show in minibuffer the main contributors of this file."
   (interactive)
   (when (and code-compass-display-file-contributors (buffer-file-name))
-    (message "Contributors of %s:\n%s" (buffer-file-name) (code-compass--contributors-list-for-current-buffer))))
+    (let ((file (buffer-file-name))
+          (parent-dir nil)
+          (common-parent nil))
+      (when (vc-root-dir)
+        (setq parent-dir (f-parent (vc-root-dir)))
+        (setq common-parent (f-common-parent `(,buffer-file-name ,parent-dir)))
+        (setq file (f-relative buffer-file-name common-parent)))
+
+      (message "Contributors of %s:\n%s" file (code-compass--contributors-list-for-current-buffer)))))
 (define-obsolete-function-alias 'c/display-contributors #'code-compass-display-contributors "0.1.2")
 
 (defun code-compass-display-contributors-delayed ()

--- a/code-compass.el
+++ b/code-compass.el
@@ -1740,6 +1740,10 @@ Starting DATE reduces scope of Git log.
   (interactive)
   (when (and code-compass-display-file-contributors (buffer-file-name))
     (let ((file-path buffer-file-name))
+      ;; When we have the ability to infer the project root, we will use that to display the relative file path
+      ;; Otherwise, we will display the entire full path.
+      ;; We can infer project root when file in question, is in VCS. If its a new file, the function won't
+      ;; be able to pick it up, so it will display the full file path.
       (when (vc-root-dir)
         (setq file-path (file-relative-name (buffer-file-name) (file-name-parent-directory (vc-root-dir)))))
       (message "Contributors of %s:\n%s" file-path (code-compass--contributors-list-for-current-buffer)))))

--- a/code-compass.el
+++ b/code-compass.el
@@ -4,7 +4,7 @@
 
 ;; Author: Andrea <andrea-dev@hotmail.com>
 ;; Version: 0.1.3
-;; Package-Requires: ((emacs "26.1") (s "1.12.0") (dash "2.13") (async "1.9.7") (simple-httpd "1.5.1") (f "0.20"))
+;; Package-Requires: ((emacs "26.1") (s "1.12.0") (dash "2.13") (async "1.9.7") (simple-httpd "1.5.1"))
 ;; Keywords: tools, extensions, help
 ;; Homepage: https://github.com/ag91/code-compass
 
@@ -1739,15 +1739,10 @@ Starting DATE reduces scope of Git log.
   "Show in minibuffer the main contributors of this file."
   (interactive)
   (when (and code-compass-display-file-contributors (buffer-file-name))
-    (let ((file (buffer-file-name))
-          (parent-dir nil)
-          (common-parent nil))
+    (let ((file-path buffer-file-name))
       (when (vc-root-dir)
-        (setq parent-dir (f-parent (vc-root-dir)))
-        (setq common-parent (f-common-parent `(,buffer-file-name ,parent-dir)))
-        (setq file (f-relative buffer-file-name common-parent)))
-
-      (message "Contributors of %s:\n%s" file (code-compass--contributors-list-for-current-buffer)))))
+        (setq file-path (file-relative-name (buffer-file-name) (file-name-parent-directory (vc-root-dir)))))
+      (message "Contributors of %s:\n%s" file-path (code-compass--contributors-list-for-current-buffer)))))
 (define-obsolete-function-alias 'c/display-contributors #'code-compass-display-contributors "0.1.2")
 
 (defun code-compass-display-contributors-delayed ()


### PR DESCRIPTION
When displaying a files contributions list, it will no longer show the entire file path but only that relative to the project root
eg
```
"/Users/gopar/projects/code-compass/code-compass.el" 
vs 
"code-compass/code-compass.el"
```

Also when file has no history, display that instead of `nil`