### PR TITLE
Run python scripts out of a virtualenv

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,26 +55,11 @@ And the following Emacs packages:
 
 - async.el
 - dash.el
-- f.el
 - s.el
 - simple-httpd
 
-
-If you use =use-package= and you are on a Linux system, this will take
-care of the Emacs installation:
-
-#+begin_src elisp :noeval
-(use-package async)
-(use-package dash)
-(use-package f)
-(use-package s)
-(use-package simple-httpd)
-
-(use-package code-compass
-  :load-path "~/.emacs.d/lisp")
-#+end_src
-
-For Docker, the Code Maat image, cloc and graph-cli run the following script:
+If you are on a Linux system, Docker, the Code Maat image, and cloc can be
+installed by running the following script:
 
 #+begin_src sh :noeval
 # Docker is only necessary if you want to use that instead of the (automatically downloaded) JAR file
@@ -87,11 +72,36 @@ For Docker, the Code Maat image, cloc and graph-cli run the following script:
 #docker build -t code-maat-app .
 
 sudo apt install cloc;
+#+end_src
 
-cd /tmp;
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; # from here https://pip.pypa.io/en/stable/installing/
-python get-pip.py --user
-pip3 install --user graph-cli # https://github.com/mcastorina/graph-cli
+Python dependencies are stored in a virtual environment managed by
+code-compass. These are installed by the function =code-compass-install=.
+
+*** Installation from Melpa
+
+Code-compass can be installed as a package using =use-package=:
+
+#+begin_src elisp :noeval
+(use-package code-compass
+  :ensure t
+  :config
+  (code-compass-install))
+#+end_src
+
+*** Installation
+
+Code-compass can be installed from manually with:
+
+#+begin_src elisp :noeval
+(use-package async)
+(use-package dash)
+(use-package s)
+(use-package simple-httpd)
+
+(use-package code-compass
+  :load-path "~/.emacs.d/lisp"
+  :config
+  (code-compass-install))
 #+end_src
 
 For trying things out in a clean Emacs:
@@ -119,7 +129,6 @@ For trying things out in a clean Emacs:
 (require 'bind-key)
 (use-package async)
 (use-package dash)
-(use-package f)
 (use-package s)
 (use-package simple-httpd)
 #+end_src

--- a/code-compass.el
+++ b/code-compass.el
@@ -47,7 +47,7 @@
 
 (defun code-compass--python-script (script)
   "Return the command to run a script with code-compass' python. "
-  (concat code-compass-download-directory "/venv/bin/python3 " script)
+  (concat code-compass-download-directory "/venv/bin/python3 " script))
 
 (defgroup code-compass nil
   "Options specific to code-compass."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+graph-cli
+PyQT5


### PR DESCRIPTION
Execute all of the Python scripts out of a virtualenv managed by code-compass and stored in the `dependencies` directory.

A new command, `code-compass-install`, will create the virtualenv populate it with required packages.

This removes the python packages from the manual installation steps, but the side effect is that every time a new version of code-compass is released then the virtualenv will be rebuilt. This is similar to how `pdf-tools` manages its local binaries. 

This, along with my previous PR, are my attempts to reduce the friction of running code-compass as a package.